### PR TITLE
Option to ignore transcript version numbers for gene merge

### DIFF
--- a/R/tximport.R
+++ b/R/tximport.R
@@ -44,7 +44,8 @@ tximport <- function(files,
                      countsCol,
                      lengthCol,
                      importer=function(x) read.table(x,header=TRUE),
-                     collatedFiles) {
+                     collatedFiles,
+                     ignore.txVersion=FALSE) {
 
   type <- match.arg(type, c("kallisto","salmon","rsem","cufflinks"))
   countsFromAbundance <- match.arg(countsFromAbundance, c("no","scaledTPM","lengthScaledTPM"))
@@ -138,6 +139,9 @@ tximport <- function(files,
     # potentially remove unassociated transcript rows and warn user
     if (!is.null(gene2tx)) {
       colnames(gene2tx) <- c("gene","tx")
+      if (ignore.txVersion) {
+        txId <- sapply(strsplit(as.character(txId), "\\."), "[[", 1)
+      }
       gene2tx$gene <- factor(gene2tx$gene)
       gene2tx$tx <- factor(gene2tx$tx)
       # remove transcripts (and genes) not in the abundances


### PR DESCRIPTION
When using @stephenturner's package (see #4) for gene annotation, I realized that his transcript annotation is not versioned. This is probably best for everyone's sanity, and if we're merging transcripts to genes I doubt the versions matter that much. So I've added an option to ignore versions based on the common convention of `accession.version`. I'm working with gencode v22 annotation FWIW.