### PR TITLE
Support for new sailfish and salmon formats

### DIFF
--- a/R/tximport.R
+++ b/R/tximport.R
@@ -75,7 +75,7 @@ tximport <- function(files,
     txIdCol <- "Name"
     abundanceCol <- "TPM"
     countsCol <- "NumReads"
-    jsonFile <- file.path(dirname(head(files)), "cmd_info.json")
+    jsonFile <- file.path(dirname(head(files, n=1)), "cmd_info.json")
     # for now, the simple existence of this file is proof enough 
     # of the new format.
     if (file.exists(jsonFile)) {

--- a/R/tximport.R
+++ b/R/tximport.R
@@ -116,7 +116,7 @@ tximport <- function(files,
     for (i in seq_along(files)) {
       message(i," ",appendLF=FALSE)
       raw <- as.data.frame(importer(files[i]))
-      head(raw)
+      
       # does the table contain gene association or was an external gene2tx table provided?
       if (is.null(gene2tx) & !txOut) {
         # e.g. Cufflinks includes the gene ID in the table

--- a/R/tximport.R
+++ b/R/tximport.R
@@ -75,13 +75,24 @@ tximport <- function(files,
     txIdCol <- "Name"
     abundanceCol <- "TPM"
     countsCol <- "NumReads"
-    lengthCol <- "Length" 
-    # because the comment lines have the same comment character as the header
-    # need to name the column names
-    importer <- function(x) {
-      tmp <- reader(x, comment="#")
-      names(tmp) <- c("Name","Length","TPM","NumReads")
-      tmp
+    jsonFile <- file.path(dirname(head(files)), "cmd_info.json")
+    # for now, the simple existence of this file is proof enough 
+    # of the new format.
+    if (file.exists(jsonFile)) {
+        lengthCol <- "EffectiveLength" 
+        importer <- function(x) { 
+          tmp <- reader(x, comment='#') 
+          tmp
+        }
+    } else {
+        lengthCol <- "Length" 
+        # because the comment lines have the same comment character as the header
+        # need to name the column names
+        importer <- function(x) {
+          tmp <- reader(x, comment="#")
+          names(tmp) <- c("Name","Length","TPM","NumReads")
+          tmp
+        }
     }
   }
   
@@ -105,7 +116,7 @@ tximport <- function(files,
     for (i in seq_along(files)) {
       message(i," ",appendLF=FALSE)
       raw <- as.data.frame(importer(files[i]))
-      
+      head(raw)
       # does the table contain gene association or was an external gene2tx table provided?
       if (is.null(gene2tx) & !txOut) {
         # e.g. Cufflinks includes the gene ID in the table


### PR DESCRIPTION
Hi Mike,

  This implements (hopefully transparent) support for reading both the new and old Sailfish and Salmon formats.  I haven't cut the new release yet, but it corresponds to the beta executable I sent you earlier.  Basically, this code just checks if a marker file exists (which is only present when processed with newer version of Sailfish and Salmon). If we're dealing with the new version, it uses an updated reading function and deals with the effective lengths directly.  *Note:* this pull request still doesn't import the effective lengths for older versions of sailfish / salmon yet.