### PR TITLE
Fix for Salmon 0.14 num_targets -> num_valid_targets issue.

### DIFF
--- a/R/infReps.R
+++ b/R/infReps.R
@@ -60,6 +60,9 @@ readInfRepFish <- function(fish_dir, meth) {
     # Now, however, both types of samples are doubles.  The code below 
     # tries to load doubles first, but falls back to integers if it fails.
     ##
+    if("num_valid_targets" %in% names(minfo)) {
+      minfo$num_targets = minfo$num_valid_targets
+    }
     expected.n <- minfo$num_targets * minfo$num_bootstraps
     boots <- tryCatch({
       bootsIn <- readBin(bootCon, "double", n = expected.n)


### PR DESCRIPTION
This is the same gotcha as in bcbio/bcbio-nextgen#2843.

Fixes #29.

Test data to show this fixes the issue can be grabbed here: https://www.dropbox.com/s/d5325xe3weo8io2/tximport-example.tar.gz?dl=1