### PR TITLE
edgeR::cpm

### DIFF
--- a/vignettes/tximport.Rmd
+++ b/vignettes/tximport.Rmd
@@ -448,10 +448,7 @@ y <- y[keep,]
 For creating a matrix of CPMs within *edgeR*, the following code chunk can be used:
 
 ```{r}
-se <- SummarizedExperiment(assays=list(counts=y$counts, offset=y$offset))
-se$totals <- y$samples$lib.size
-library(csaw)
-cpms <- calculateCPM(se, use.offsets=TRUE, log=FALSE)
+cpms <- edgeR::cpm(y, offset=y$offset, log=FALSE)
 ```
 
 ## DESeq2


### PR DESCRIPTION
Since v3.32.0 edgeR can directly use offsets in its cpm methods, see http://bioconductor.org/packages/release/bioc/news/edgeR/NEWS so one does not need the path via csaw/SummarizedExperiment anymore. Adding as "edgeR::cpm" rather than "cpm" alone since the SingleCellExperiment package masks the cpm function.