### PR TITLE
make filterByExpr use design information

### DIFF
--- a/vignettes/tximport.Rmd
+++ b/vignettes/tximport.Rmd
@@ -442,8 +442,10 @@ normMat <- log(normMat)
 # Creating a DGEList object for use in edgeR.
 y <- DGEList(cts)
 y <- scaleOffset(y, normMat)
-# filtering
-keep <- filterByExpr(y)
+
+# filtering using the design information
+design <- model.matrix(~ condition, data=sampleTable)
+keep <- filterByExpr(y, design)
 y <- y[keep,]
 # y is now ready for estimate dispersion functions
 # see edgeR User's Guide
@@ -494,11 +496,14 @@ txi <- tximport(files, type="salmon",
                 countsFromAbundance="lengthScaledTPM")
 library(limma)
 y <- DGEList(txi$counts)
-# filtering
-keep <- filterByExpr(y)
-y <- y[keep,]
-y <- calcNormFactors(y)
+
+# filtering using the design information:
 design <- model.matrix(~ condition, data=sampleTable)
+keep <- filterByExpr(y, design)
+y <- y[keep,]
+
+# normalize and run voom transformation
+y <- calcNormFactors(y)
 v <- voom(y, design)
 # v is now ready for lmFit()
 # see limma User's Guide


### PR DESCRIPTION
Tiny change in the vignette for the `limma-voom/edgeR` parts to make `filterByExpr()` use the design information. That will remove the warning that is currently printed (`Warning in filterByExpr.DGEList(y):...`) and is exactly what `?filterByExpr` recommends in its example section.