### PR TITLE
Add initial support for `piscem-infer`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ VignetteBuilder: knitr
 Imports: utils, stats, methods
 Suggests: knitr, rmarkdown, testthat, tximportData,
         TxDb.Hsapiens.UCSC.hg19.knownGene, readr (>= 0.2.2),
-	limma, edgeR, DESeq2 (>= 1.11.6),
+	arrow, limma, edgeR, DESeq2 (>= 1.11.6),
 	rhdf5, jsonlite, matrixStats, Matrix, eds
 URL: https://github.com/thelovelab/tximport
 biocViews: DataImport, Preprocessing,

--- a/R/infReps.R
+++ b/R/infReps.R
@@ -85,6 +85,30 @@ readInfRepFish <- function(fish_dir, meth) {
   }
 }
 
+# read inferential replicates from piscem-infer
+readInfRepPiscem <- function(fish_file) {
+  # look for the quant file (ending in `quant`, hence the $ below) and
+  # replace it with `infreps.pq`.
+  parquet_file <- sub("quant$", "infreps.pq", fish_file)
+  if (!file.exists(fish_file)) return(NULL)
+  if (!requireNamespace("arrow", quietly=TRUE)) {
+    stop("reading piscem-infer results from Parquet files requires package `arrow`")
+  }
+  boots <- arrow::read_parquet(parquet_file)
+  numBoot <- length(boots)
+  if (numBoot > 0) {
+    numTxp <- length(boots$bootstrap.0)
+    bootMat <- matrix(nrow=numTxp, ncol=numBoot)
+    for (bsn in seq_len(numBoot)) {
+      bootMat[,bsn] <- boots[bsn][[1]]
+    }
+    vars <- rowVars(bootMat)
+    return(list(vars=vars, reps=bootMat))
+  } else {
+    return(NULL)
+  }
+}
+
 readInfRepKallisto <- function(bear_dir) {
   h5File <- file.path(bear_dir, "abundance.h5")
   if (!file.exists(h5File)) return(NULL)


### PR DESCRIPTION
This adds support for [`piscem-infer`](https://github.com/COMBINE-lab/piscem-infer) to `tximport`.  This PR provides the ability to load both the quantifications as well as the inferential replicates if they are present.  See the commit message for more details. Note: To load the inferential replicates, which are stored in Parquet format, this makes use of the `arrow` package, which the user must have installed.  If it is not installed, this will issue a warning to that effect.